### PR TITLE
Make Date conform to MultipartConvertible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Packages
 Package.pins
 Package.resolved
 DerivedData
+.swiftpm

--- a/Sources/Multipart/MultipartPartConvertible.swift
+++ b/Sources/Multipart/MultipartPartConvertible.swift
@@ -137,30 +137,43 @@ extension Data: MultipartPartConvertible {
 }
 
 extension Date: MultipartPartConvertible {
+    
+    static var useISO8601ForMultipart = true
+    
     /// See `MultipartPartConvertible`.
     public func convertToMultipartPart() throws -> MultipartPart {
-        if #available(macOS 10.12, *) {
-            let dateFormatter = ISO8601DateFormatter()
-            let string = dateFormatter.string(from: self)
-            return MultipartPart(data: string)
+        if Date.useISO8601ForMultipart {
+            if #available(macOS 10.12, *) {
+                let dateFormatter = ISO8601DateFormatter()
+                let string = dateFormatter.string(from: self)
+                return MultipartPart(data: string)
+            } else {
+                throw MultipartError(identifier: "ISO 8601", reason: "macOS SDK < 10.12 detected, no ISO-8601 DateFormatter support.")
+            }
         } else {
-            throw MultipartError(identifier: "ISO 8601", reason: "macOS SDK < 10.12 detected, no ISO-8601 DateFormatter support.")
+            let doubleValue: Double = self.timeIntervalSince1970
+            return try doubleValue.convertToMultipartPart()
         }
     }
     
     /// See `MultipartPartConvertible`.
     public static func convertFromMultipartPart(_ part: MultipartPart) throws -> Date {
-        guard let string = String(data: part.data, encoding: .utf8) else {
-            throw MultipartError(identifier: "utf8", reason: "Could not convert `Data` to UTF-8 `String`.")
-        }
-        if #available(macOS 10.12, *) {
-            let dateFormatter = ISO8601DateFormatter()
-            guard let date = dateFormatter.date(from: string) else {
-                throw MultipartError(identifier: "DateFormatter", reason: "Could not convert `String` to `Date`")
+        if Date.useISO8601ForMultipart {
+            guard let string = String(data: part.data, encoding: .utf8) else {
+                throw MultipartError(identifier: "utf8", reason: "Could not convert `Data` to UTF-8 `String`.")
             }
-            return date
+            if #available(macOS 10.12, *) {
+                let dateFormatter = ISO8601DateFormatter()
+                guard let date = dateFormatter.date(from: string) else {
+                    throw MultipartError(identifier: "DateFormatter", reason: "Could not convert `String` to `Date`")
+                }
+                return date
+            } else {
+                throw MultipartError(identifier: "ISO 8601", reason: "macOS SDK < 10.12 detected, no ISO-8601 DateFormatter support.")
+            }
         } else {
-            throw MultipartError(identifier: "ISO 8601", reason: "macOS SDK < 10.12 detected, no ISO-8601 DateFormatter support.")
+            let doubleValue = try Double.convertFromMultipartPart(part)
+            return Date(timeIntervalSince1970: doubleValue)
         }
     }
 }

--- a/Sources/Multipart/MultipartPartConvertible.swift
+++ b/Sources/Multipart/MultipartPartConvertible.swift
@@ -135,3 +135,32 @@ extension Data: MultipartPartConvertible {
         return part.data
     }
 }
+
+extension Date: MultipartPartConvertible {
+    /// See `MultipartPartConvertible`.
+    public func convertToMultipartPart() throws -> MultipartPart {
+        if #available(macOS 10.12, *) {
+            let dateFormatter = ISO8601DateFormatter()
+            let string = dateFormatter.string(from: self)
+            return MultipartPart(data: string)
+        } else {
+            throw MultipartError(identifier: "ISO 8601", reason: "macOS SDK < 10.12 detected, no ISO-8601 DateFormatter support.")
+        }
+    }
+    
+    /// See `MultipartPartConvertible`.
+    public static func convertFromMultipartPart(_ part: MultipartPart) throws -> Date {
+        guard let string = String(data: part.data, encoding: .utf8) else {
+            throw MultipartError(identifier: "utf8", reason: "Could not convert `Data` to UTF-8 `String`.")
+        }
+        if #available(macOS 10.12, *) {
+            let dateFormatter = ISO8601DateFormatter()
+            guard let date = dateFormatter.date(from: string) else {
+                throw MultipartError(identifier: "DateFormatter", reason: "Could not convert `String` to `Date`")
+            }
+            return date
+        } else {
+            throw MultipartError(identifier: "ISO 8601", reason: "macOS SDK < 10.12 detected, no ISO-8601 DateFormatter support.")
+        }
+    }
+}

--- a/Tests/MultipartTests/MultipartTests.swift
+++ b/Tests/MultipartTests/MultipartTests.swift
@@ -81,8 +81,10 @@ class MultipartTests: XCTestCase {
             var double: Double
             var array: [Int]
             var bool: Bool
+            var date: Date
         }
-        let a = Foo(string: "a", int: 42, double: 3.14, array: [1, 2, 3], bool: true)
+        let date = Date(timeIntervalSince1970: 1571392115)
+        let a = Foo(string: "a", int: 42, double: 3.14, array: [1, 2, 3], bool: true, date: date)
         let data = try FormDataEncoder().encode(a, boundary: "hello")
         XCTAssertEqual(data.utf8, """
         --hello\r
@@ -113,6 +115,10 @@ class MultipartTests: XCTestCase {
         Content-Disposition: form-data; name="bool"\r
         \r
         true\r
+        --hello\r
+        Content-Disposition: form-data; name=\"date\"\r
+        \r
+        2019-10-18T09:48:35Z\r
         --hello--\r\n
         """)
     }


### PR DESCRIPTION
This brings parity between JSON and Form encoding and decoding of dates by using ISO8601 for multipart instead of epoch time and doubles