### PR TITLE
Improve parsing performance

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
@@ -17,6 +17,6 @@ let package = Package(
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
         ]),
-        .testTarget(name: "MultipartKitTests", dependencies: ["MultipartKit"]),
+        .testTarget(name: "MultipartKitTests", dependencies: ["MultipartKit"], resources: [.copy("request-body.txt")]),
     ]
 )

--- a/Sources/MultipartKit/MultipartParser.swift
+++ b/Sources/MultipartKit/MultipartParser.swift
@@ -94,7 +94,19 @@ public final class MultipartParser {
         }
     }
 
-    private func readByte() -> UInt8? { buffer.readInteger() }
+    var maxWorkingBytes: Int = 1024 // 1KB
+    var internalBuffer: [UInt8] = []
+
+    private func readByte() -> UInt8? {
+//        return buffer.readInteger()
+        if internalBuffer.isEmpty && buffer.readableBytes > 0 {
+            guard let workingBytes = buffer.readBytes(length: min(buffer.readableBytes, maxWorkingBytes)) else {
+                preconditionFailure("unable to read bytes")
+            }
+            internalBuffer = workingBytes
+        }
+        return internalBuffer.removeFirst()
+    }
 
     private func parsePreamble(boundaryMatchIndex: Int) -> State {
         var boundaryMatchIndex = boundaryMatchIndex

--- a/Sources/MultipartKit/MultipartParser.swift
+++ b/Sources/MultipartKit/MultipartParser.swift
@@ -52,6 +52,7 @@ public final class MultipartParser {
 
     private var internalBuffer: [UInt8] = []
     private var internalBufferPtr: Int = 0
+    private var internalReaderIndex: Int = 0
 
     /// Creates a new `MultipartParser`.
     /// - Parameter boundary: boundary separating parts. Must not be empty nor longer than 70 characters according to rfc1341 but we don't check for the latter.
@@ -84,7 +85,7 @@ public final class MultipartParser {
 
         self.internalBuffer = []
         self.internalBufferPtr = 0
-        self.offset = 0
+        self.internalReaderIndex = 0
 
         try execute()
     }
@@ -113,10 +114,9 @@ public final class MultipartParser {
     }
 
     private func readerIndex() -> Int {
-        return offset + internalBufferPtr
+        return internalReaderIndex + internalBufferPtr
     }
 
-    var offset: Int = 0
 
     private func readByte() -> UInt8? {
 //        return buffer.readInteger()
@@ -129,7 +129,7 @@ public final class MultipartParser {
 
 //            debugPrint("read more bytes")
 
-            buffer.moveReaderIndex(to: offset + internalBufferPtr)
+            buffer.moveReaderIndex(to: internalReaderIndex + internalBufferPtr)
             let idx = buffer.readerIndex
 
             guard buffer.readableBytes > 0 else {
@@ -150,7 +150,7 @@ public final class MultipartParser {
             buffer.moveReaderIndex(to: idx)
 //            debugPrint(buffer.readerIndex, idx)
 
-            offset = idx
+            internalReaderIndex = idx
             internalBuffer = workingBytes
             internalBufferPtr = 0
 

--- a/Tests/MultipartKitTests/MultipartKitTests.swift
+++ b/Tests/MultipartKitTests/MultipartKitTests.swift
@@ -366,7 +366,7 @@ class MultipartTests: XCTestCase {
 
         measure(options: opts) {
             do {
-                let output = try MultipartDataParserOutputReceiver.collectOutput(buf: buf, boundary: "__X_PAW_BOUNDARY__")
+                let _ = try MultipartDataParserOutputReceiver.collectOutput(buf: buf, boundary: "__X_PAW_BOUNDARY__")
             } catch {
                 XCTFail(error.localizedDescription)
             }

--- a/Tests/MultipartKitTests/MultipartKitTests.swift
+++ b/Tests/MultipartKitTests/MultipartKitTests.swift
@@ -361,10 +361,7 @@ class MultipartTests: XCTestCase {
         let data = try Data(contentsOf: dataURL)
         let buf = ByteBuffer(bytes: data)
 
-        let opts = XCTMeasureOptions.default
-        opts.iterationCount = 4
-
-        measure(options: opts) {
+        measure {
             do {
                 let _ = try MultipartDataParserOutputReceiver.collectOutput(buf: buf, boundary: "__X_PAW_BOUNDARY__")
             } catch {


### PR DESCRIPTION
### Context
I noticed the performance when parsing large bodies was a little slow. For a 25MB request body, this was taking ~80s to parse.

Took a little time to naively implement some improvements bringing the parse time for that same 25MB request down to ~6s (so far). I'm sure there's more that can be done, but in the interest of small incremental improvements, those can be addressed in other PRs.

### Changes
- Found that the slowdown was from `ByteBuffer.readInteger`
- Changed from reading a single `UInt8`, to an array of `UInt8`s (of configurable size, defaulting to 1KB)
- Store the read data into `internalBuffer` and an `internalBufferPtr` to represent the current read index in that array
- Read directly from the `internalBuffer` and re-fill when the index reaches the end

### Additional thoughts
There're some similarities with `internalBuffer` and `ByteBuffer` which suggest this could likely be solved by changing how bytes are read from `buffer` (vs. maintaining a separate `UInt8` array). I'm not sure if it's because each call of `ByteBuffer.readInteger` does some checks (i.e. for every byte vs every 1KB chunk) or if it's something else.

Investigating this is a little outside what I can set aside time for. If anyone looks into this and wants to suggest a more straight-forward way of doing this, I'll happily update my PR.

Thanks!

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
