### PR TITLE
Fix regression that broke falling back to Codable

### DIFF
--- a/Sources/MultipartKit/FormDataDecoder.swift
+++ b/Sources/MultipartKit/FormDataDecoder.swift
@@ -228,7 +228,12 @@ private extension MultipartFormData {
 private extension MultipartPart {
     func decode<T>(_ type: T.Type, at codingPath: [CodingKey]) throws -> T where T: Decodable {
         guard
-            let Convertible = T.self as? MultipartPartConvertible.Type,
+            let Convertible = T.self as? MultipartPartConvertible.Type
+        else {
+            return try T(from: _FormDataDecoder(codingPath: codingPath, data: .single(self)))
+        }
+
+        guard
             let decoded = Convertible.init(multipart: self) as? T
         else {
             let path = codingPath.map(\.stringValue).joined(separator: ".")

--- a/Sources/MultipartKit/MultipartPartConvertible.swift
+++ b/Sources/MultipartKit/MultipartPartConvertible.swift
@@ -20,7 +20,7 @@ extension String: MultipartPartConvertible {
     public var multipart: MultipartPart? {
         return MultipartPart(body: self)
     }
-    
+
     public init?(multipart: MultipartPart) {
         self.init(decoding: multipart.body.readableBytesView, as: UTF8.self)
     }
@@ -30,7 +30,7 @@ extension FixedWidthInteger {
     public var multipart: MultipartPart? {
         return MultipartPart(body: self.description)
     }
-    
+
     public init?(multipart: MultipartPart) {
         guard let string = String(multipart: multipart) else {
             return nil
@@ -54,7 +54,7 @@ extension Float: MultipartPartConvertible {
     public var multipart: MultipartPart? {
         return MultipartPart(body: self.description)
     }
-    
+
     public init?(multipart: MultipartPart) {
         guard let string = String(multipart: multipart) else {
             return nil
@@ -67,7 +67,7 @@ extension Double: MultipartPartConvertible {
     public var multipart: MultipartPart? {
         return MultipartPart(body: self.description)
     }
-    
+
     public init?(multipart: MultipartPart) {
         guard let string = String(multipart: multipart) else {
             return nil
@@ -80,7 +80,7 @@ extension Bool: MultipartPartConvertible {
     public var multipart: MultipartPart? {
         return MultipartPart(body: self.description)
     }
-    
+
     public init?(multipart: MultipartPart) {
         guard let string = String(multipart: multipart) else {
             return nil
@@ -96,18 +96,5 @@ extension Data: MultipartPartConvertible {
     
     public init?(multipart: MultipartPart) {
         self.init(multipart.body.readableBytesView)
-    }
-}
-
-extension UUID: MultipartPartConvertible {
-    public var multipart: MultipartPart? {
-        .init(body: uuidString)
-    }
-
-    public init?(multipart: MultipartPart) {
-        guard let string = String(multipart: multipart) else {
-            return nil
-        }
-        self.init(uuidString: string)
     }
 }


### PR DESCRIPTION
Fixes regression that broke falling back to `Codable` for types not conforming to `MultipartPartConvertible` (#66, fixes #65)

Note: this removes conformance of `UUID` to `MultipartPartConvertible` introduced in 4.2.0 because it is no longer needed.
