### PR TITLE
Fix the bug of not decoding nested `Array` of Object

### DIFF
--- a/Sources/MultipartKit/MultipartFormData.swift
+++ b/Sources/MultipartKit/MultipartFormData.swift
@@ -41,15 +41,14 @@ extension MultipartFormData {
     private static func namedParts(from data: MultipartFormData, path: String? = nil) -> [MultipartPart] {
         switch data {
         case .array(let array):
-            switch array.first {
-            case .keyed:
-                return array.enumerated().flatMap { i, part in
-                    namedParts(from: part, path: path.map { "\($0)[\(i)]" })
-                }
-            default:
-                return array.flatMap {
-                    namedParts(from: $0, path: path.map { "\($0)[]" })
-                }
+            return array.enumerated().flatMap { i, part in
+                namedParts(from: part,
+                           path: {
+                            if case .keyed = part {
+                                return path.map { "\($0)[\(i)]" }
+                            }
+                            return path.map { "\($0)[]" }
+                           }())
             }
         case .single(var part):
             part.name = path

--- a/Sources/MultipartKit/MultipartFormData.swift
+++ b/Sources/MultipartKit/MultipartFormData.swift
@@ -7,10 +7,8 @@ enum MultipartFormData: Equatable {
 
     init(parts: [MultipartPart], nestingDepth: Int) {
         self = parts.reduce(into: .empty) { result, part in
-            print(part.name.map(path))
             result.insertingPart(part, at: part.name.map(path) ?? [], remainingNestingLevels: nestingDepth)
         }
-        print(self)
     }
 
     static let empty = MultipartFormData.keyed([:])

--- a/Sources/MultipartKit/MultipartFormData.swift
+++ b/Sources/MultipartKit/MultipartFormData.swift
@@ -7,10 +7,8 @@ enum MultipartFormData: Equatable {
 
     init(parts: [MultipartPart], nestingDepth: Int) {
         self = parts.reduce(into: .empty) { result, part in
-            print(part.name.map(path) ?? [])
             result.insertingPart(part, at: part.name.map(path) ?? [], remainingNestingLevels: nestingDepth)
         }
-        print(self)
     }
 
     static let empty = MultipartFormData.keyed([:])

--- a/Sources/MultipartKit/MultipartFormData.swift
+++ b/Sources/MultipartKit/MultipartFormData.swift
@@ -7,8 +7,10 @@ enum MultipartFormData: Equatable {
 
     init(parts: [MultipartPart], nestingDepth: Int) {
         self = parts.reduce(into: .empty) { result, part in
+            print(part.name.map(path) ?? [])
             result.insertingPart(part, at: part.name.map(path) ?? [], remainingNestingLevels: nestingDepth)
         }
+        print(self)
     }
 
     static let empty = MultipartFormData.keyed([:])
@@ -72,7 +74,7 @@ private extension MultipartFormData {
             case .none, "":
                 return .array((array ?? []) + [MultipartFormData.empty.insertPart(part, at: path.dropFirst(), remainingNestingLevels: remainingNestingLevels - 1)])
             case let .some(head):
-                if array == nil || array!.last!.dictionary!.keys.contains(String(head)) {
+                if array == nil || (array!.last!.dictionary!.keys.contains(String(head)) && path.count == 2) {
                     return .array((array ?? []) + [MultipartFormData.empty.insertPart(part, at: path.dropFirst(), remainingNestingLevels: remainingNestingLevels - 1)])
                 } else {
                     return .array(array!.dropLast() + [array!.last!.insertPart(part, at: path.dropFirst(), remainingNestingLevels: remainingNestingLevels - 1)])

--- a/Tests/MultipartKitTests/MultipartKitTests.swift
+++ b/Tests/MultipartKitTests/MultipartKitTests.swift
@@ -423,11 +423,12 @@ class MultipartTests: XCTestCase {
 
         XCTAssertEqual(data, expected)
     }
-
+    
     func testNestedDecode() throws {
         struct Foo: Decodable, Equatable {
             struct Bar: Decodable, Equatable {
                 let baz: Int
+                let bazString: String
             }
             let bar: Bar
             let bars: [Bar]
@@ -439,11 +440,23 @@ class MultipartTests: XCTestCase {
         \r
         1\r
         ---\r
+        Content-Disposition: form-data; name="bar[bazString]"\r
+        \r
+        1\r
+        ---\r
         Content-Disposition: form-data; name="bars[][baz]"\r
         \r
         2\r
         ---\r
+        Content-Disposition: form-data; name="bars[][bazString]"\r
+        \r
+        2\r
+        ---\r
         Content-Disposition: form-data; name="bars[][baz]"\r
+        \r
+        3\r
+        ---\r
+        Content-Disposition: form-data; name="bars[][bazString]"\r
         \r
         3\r
         -----\r\n
@@ -452,7 +465,7 @@ class MultipartTests: XCTestCase {
         let decoder = FormDataDecoder()
         let foo = try decoder.decode(Foo.self, from: data, boundary: "-")
 
-        XCTAssertEqual(foo, Foo(bar: .init(baz: 1), bars: [.init(baz: 2), .init(baz: 3)]))
+        XCTAssertEqual(foo, Foo(bar: .init(baz: 1, bazString: "1"), bars: [.init(baz: 2, bazString: "2"), .init(baz: 3, bazString: "3")]))
     }
 
     func testDecodingSingleValue() throws {

--- a/Tests/MultipartKitTests/MultipartKitTests.swift
+++ b/Tests/MultipartKitTests/MultipartKitTests.swift
@@ -424,38 +424,7 @@ class MultipartTests: XCTestCase {
         XCTAssertEqual(data, expected)
     }
     
-    func testNestedDecode1() throws {
-        struct Foo: Decodable, Equatable {
-            struct Bar: Decodable, Equatable {
-                let baz: Int
-            }
-            let bar: Bar
-            let bars: [Bar]
-        }
-
-        let data = """
-        ---\r
-        Content-Disposition: form-data; name="bar[baz]"\r
-        \r
-        1\r
-        ---\r
-        Content-Disposition: form-data; name="bars[][baz]"\r
-        \r
-        2\r
-        ---\r
-        Content-Disposition: form-data; name="bars[][baz]"\r
-        \r
-        3\r
-        -----\r\n
-        """
-
-        let decoder = FormDataDecoder()
-        let foo = try decoder.decode(Foo.self, from: data, boundary: "-")
-
-        XCTAssertEqual(foo, (Foo(bar: .init(baz: 1), bars: [.init(baz: 2), .init(baz: 3)])))
-    }
-    
-    func testNestedDecode2() throws {
+    func testNestedDecode() throws {
         struct Formdata: Decodable, Equatable {
             struct NestedFormdata: Decodable, Equatable {
                 struct AnotherNestedFormdata: Decodable, Equatable {
@@ -555,69 +524,6 @@ class MultipartTests: XCTestCase {
         ]))
     }
     
-//    func testNestedDecode() throws {
-//        struct Foo: Decodable, Equatable {
-//            struct Bar: Decodable, Equatable {
-//                let bazA: Int
-//                let bazB: String
-//            }
-//            let bar: Bar
-//            let bars: [Bar]
-//        }
-//
-//        let data = """
-//        ---\r
-//        Content-Disposition: form-data; name="bar[bazA]"\r
-//        \r
-//        1\r
-//        ---\r
-//        Content-Disposition: form-data; name="bar[bazB]"\r
-//        \r
-//        1\r
-//        ---\r
-//        Content-Disposition: form-data; name="bars[][bazA]"\r
-//        \r
-//        2\r
-//        ---\r
-//        Content-Disposition: form-data; name="bars[][bazB]"\r
-//        \r
-//        2\r
-//        ---\r
-//        Content-Disposition: form-data; name="bars[][bazA]"\r
-//        \r
-//        3\r
-//        ---\r
-//        Content-Disposition: form-data; name="bars[][bazB]"\r
-//        \r
-//        3\r
-//        -----\r\n
-//        """
-//
-//        let decoder = FormDataDecoder()
-//        let foo = try decoder.decode(Foo.self, from: data, boundary: "-")
-//
-//        XCTAssertEqual(foo, Foo(bar: .init(bazA: 1, bazB: "1"), bars: [.init(bazA: 2, bazB: "2"), .init(bazA: 3, bazB: "3")]))
-//    }
-    
-//    func testNestedDecodeFromEncoder() throws {
-//        struct Foo: Codable, Equatable {
-//            struct Bar: Codable, Equatable {
-//                let baz: Int
-//                let bazString: String
-//            }
-//            let bar: Bar
-//            let bars: [Bar]
-//        }
-//        let encoder = FormDataEncoder()
-//        let data = try encoder.encode(Foo.self, boundary: "-")
-//
-//        let decoder = FormDataDecoder()
-//        let foo = try decoder.decode(Foo.self, from: data, boundary: "-")
-//
-//        XCTAssertEqual(foo, Foo(bar: .init(baz: 1, bazString: "1"), bars: [.init(baz: 2, bazString: "2"), .init(baz: 3, bazString: "3")]))
-//    }
-//
-
     func testDecodingSingleValue() throws {
         let data = """
         ---\r


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Fix the problem that `Multipart-kit` could not decode nested `Array` of Object mentioned in #67. 
<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
