### PR TITLE
Remove platform requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,6 @@ import PackageDescription
 
 let package = Package(
     name: "multipart-kit",
-    platforms: [
-       .macOS(.v10_15)
-    ],
     products: [
         .library(name: "MultipartKit", targets: ["MultipartKit"]),
     ],


### PR DESCRIPTION
Remove the platform requirements as they're not needed and it allows MultipartKit to be used on more platforms.

Resolves #77 