### PR TITLE
Fix for recursion loop in decoding

### DIFF
--- a/Sources/MultipartKit/FormDataDecoder/FormDataDecoder.Decoder.swift
+++ b/Sources/MultipartKit/FormDataDecoder/FormDataDecoder.Decoder.swift
@@ -3,6 +3,16 @@ extension FormDataDecoder {
         let codingPath: [CodingKey]
         let data: MultipartFormData
         let userInfo: [CodingUserInfoKey: Any]
+        let previousCodingPath : [CodingKey]?
+        let previousType: Decodable.Type?
+
+        init(codingPath: [CodingKey], data: MultipartFormData, userInfo: [CodingUserInfoKey: Any], previousCodingPath: [CodingKey]? = nil, previousType: Decodable.Type? = nil) {
+            self.codingPath = codingPath
+            self.data = data
+            self.userInfo = userInfo
+            self.previousCodingPath = previousCodingPath
+            self.previousType = previousType
+        }
     }
 }
 

--- a/Sources/MultipartKit/FormDataDecoder/FormDataDecoder.SingleValueContainer.swift
+++ b/Sources/MultipartKit/FormDataDecoder/FormDataDecoder.SingleValueContainer.swift
@@ -8,7 +8,10 @@ extension FormDataDecoder.Decoder: SingleValueDecodingContainer {
             let part = data.part,
             let Convertible = T.self as? MultipartPartConvertible.Type
         else {
-            return try T(from: self)
+            guard previousCodingPath?.count != codingPath.count || previousType != T.self else {
+                throw DecodingError.dataCorrupted(.init(codingPath: codingPath, debugDescription: "Decoding caught in recursion loop"))
+            }
+            return try T(from: FormDataDecoder.Decoder(codingPath: codingPath, data: data, userInfo: userInfo, previousCodingPath: codingPath, previousType: T.self))
         }
 
         guard !data.hasExceededNestingDepth else {

--- a/Tests/MultipartKitTests/FormDataTests.swift
+++ b/Tests/MultipartKitTests/FormDataTests.swift
@@ -493,4 +493,23 @@ class FormDataTests: XCTestCase {
         XCTAssertEqual(try FormDataEncoder().encode(license, boundary: "-"), multipart)
         XCTAssertEqual(try FormDataDecoder().decode(License.self, from: multipart, boundary: "-"), license)
     }
+
+    func testIncorrectlyNestedData() throws {
+        struct TestData : Codable {
+            var x: String
+        }
+        let multipart = """
+                   ---\r
+                   Content-Disposition: form-data; name="x[not-present]"\r
+                   \r
+                   foo\r
+                   -----\r
+                   """
+        do {
+            let _ = try FormDataDecoder().decode(TestData.self, from: multipart, boundary: "-")
+            XCTFail("This data should not decode successfully")
+        } catch {
+            // Do nothing, as long as the code did not crash
+        }
+    }
 }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

We learned through experience that it is possible to crash the Swift process through a specific combination of client multipart data and decoding; when the Decodable object is expecting a single part, but what it receives is a set of keys, the code in FormDataDecoder.SingleValueContainer will become caught in an infinite recursion and crash the process.

While the particular situation seems relatively unlikely, it seems that we would want the decoding process to throw in this case instead of crash, so this PR introduces a test and a fix.

Open to any suggestions on a better way to break the recursion.


<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
