### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Add MultiPartKit to your target's dependencies:
 targets: [
     .target(name: "MyAppTarget", dependencies: [
         // ...
-        .product(name: "MultiPartKit", package: "multipart-kit"),
+        .product(name: "MultipartKit", package: "multipart-kit"),
     ])
 ]
 ```


### PR DESCRIPTION
Adding this library to my vapor project fails with error:

```
product 'MultiPartKit' required by package
'connect-server' target 'App' not found in package 'multipart-kit'.
```

in Package.swift the library name is slightly different and once changed the project compiles

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
