### PR TITLE
Remove no longer needed `@preconcurrency` attribute

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "MultipartKit", targets: ["MultipartKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.61.1"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.5"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "MultipartKit", targets: ["MultipartKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.61.1"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.5"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
     ],
     targets: [
         .target(

--- a/Sources/MultipartKit/MultipartFormData.swift
+++ b/Sources/MultipartKit/MultipartFormData.swift
@@ -1,4 +1,4 @@
-@preconcurrency import Collections
+import Collections
 
 enum MultipartFormData: Equatable, Sendable {
     typealias Keyed = OrderedDictionary<String, MultipartFormData>


### PR DESCRIPTION
`swift-collections` has since been updated to make the attribute unnecessary.