### PR TITLE
Exclude `docc` files from sources to avoid build warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "Collections", package: "swift-collections"),
-            ]
+            ],
+            exclude: ["Docs.docc"]
         ),
         .testTarget(
             name: "MultipartKitTests",


### PR DESCRIPTION
When using this package as a dependency, the following warning appears during the build process:

```
warning: 'multipart-kit': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/omochi/<myproject>/.build/checkouts/multipart-kit/Sources/MultipartKit/Docs.docc
```

This happens because `docc` files are treated as undefined source files.
This patch explicitly excludes them using the exclude directive, clarifying that they are not source files and preventing the warning from being displayed.