### PR TITLE
Remove useless `Equatable` constraint

### DIFF
--- a/Benchmarks/Parser/AsyncSyncSequence.swift
+++ b/Benchmarks/Parser/AsyncSyncSequence.swift
@@ -31,7 +31,7 @@ final class AsyncSyncSequence<Base: Sequence>: AsyncSequence {
     }
 
     func makeAsyncIterator() -> Iterator {
-        defer { self.base = nil } // release the reference so no CoW is triggered
+        defer { self.base = nil }  // release the reference so no CoW is triggered
         return Iterator(base.unsafelyUnwrapped.makeIterator())
     }
 }

--- a/Benchmarks/Parser/Parser.swift
+++ b/Benchmarks/Parser/Parser.swift
@@ -1,4 +1,3 @@
-import Algorithms
 import Benchmark
 import MultipartKit
 

--- a/Sources/MultipartKit/MultipartFormData.swift
+++ b/Sources/MultipartKit/MultipartFormData.swift
@@ -1,7 +1,7 @@
 import Collections
 import Foundation
 
-enum MultipartFormData<Body: MultipartPartBodyElement>: Equatable, Sendable {
+enum MultipartFormData<Body: MultipartPartBodyElement>: Sendable {
     typealias Keyed = OrderedDictionary<String, MultipartFormData>
 
     case single(MultipartPart<Body>)

--- a/Sources/MultipartKit/MultipartPart.swift
+++ b/Sources/MultipartKit/MultipartPart.swift
@@ -1,9 +1,9 @@
 import HTTPTypes
 
-public typealias MultipartPartBodyElement = Collection<UInt8> & Equatable & Sendable
+public typealias MultipartPartBodyElement = Collection<UInt8> & Sendable
 
 /// Represents a single part of a multipart-encoded message.
-public struct MultipartPart<Body: MultipartPartBodyElement>: Equatable, Sendable {
+public struct MultipartPart<Body: MultipartPartBodyElement>: Sendable {
     /// The header fields for this part.
     public var headerFields: HTTPFields
 

--- a/Sources/MultipartKit/MultipartSection.swift
+++ b/Sources/MultipartKit/MultipartSection.swift
@@ -1,6 +1,6 @@
 import HTTPTypes
 
-public enum MultipartSection<Body: MultipartPartBodyElement>: Equatable, Sendable {
+public enum MultipartSection<Body: MultipartPartBodyElement>: Sendable {
     case headerFields(HTTPFields)
     case bodyChunk(Body)
     case boundary(end: Bool)

--- a/Tests/MultipartKitTests/Utilities/MultipartSection+Equatable.swift
+++ b/Tests/MultipartKitTests/Utilities/MultipartSection+Equatable.swift
@@ -1,0 +1,14 @@
+extension MultipartSection: Equatable where Body: Equatable {
+    public static func == (lhs: MultipartKit.MultipartSection<Body>, rhs: MultipartKit.MultipartSection<Body>) -> Bool {
+        switch (lhs, rhs) {
+        case let (.headerFields(lhsFields), .headerFields(rhsFields)):
+            lhsFields == rhsFields
+        case let (.bodyChunk(lhsChunk), .bodyChunk(rhsChunk)):
+            lhsChunk == rhsChunk
+        case (.boundary, .boundary):
+            true
+        default:
+            false
+        }
+    }
+}

--- a/Tests/MultipartKitTests/Utilities/MultipartSection+Equatable.swift
+++ b/Tests/MultipartKitTests/Utilities/MultipartSection+Equatable.swift
@@ -1,3 +1,5 @@
+import MultipartKit
+
 extension MultipartSection: Equatable where Body: Equatable {
     public static func == (lhs: MultipartKit.MultipartSection<Body>, rhs: MultipartKit.MultipartSection<Body>) -> Bool {
         switch (lhs, rhs) {


### PR DESCRIPTION
We can get rid of the `Equatable` requirement in the multiparty body type typealias since it was really just used in tests