### PR TITLE
Adopt typed throws and isolation based methods for iterators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Package.pins
 Package.resolved
 DerivedData
 .swiftpm
+.index-build/

--- a/Sources/MultipartKit/MultipartMessageError.swift
+++ b/Sources/MultipartKit/MultipartMessageError.swift
@@ -1,4 +1,0 @@
-/// Higher level semantic/structural errors.
-package enum MultipartMessageError: Error, Equatable {
-    case unexpectedEndOfFile
-}

--- a/Sources/MultipartKit/MultipartParser+parse.swift
+++ b/Sources/MultipartKit/MultipartParser+parse.swift
@@ -36,7 +36,7 @@ extension MultipartParser {
             case .needMoreData:
                 // In synchronous parsing with all data provided upfront,
                 // needing more data indicates an incomplete/corrupted message
-                throw MultipartMessageError.unexpectedEndOfFile
+                throw MultipartParserError.unexpectedEndOfFile
 
             case .error(let error):
                 throw error

--- a/Sources/MultipartKit/MultipartParserAsyncSequence.swift
+++ b/Sources/MultipartKit/MultipartParserAsyncSequence.swift
@@ -38,8 +38,15 @@ where BackingSequence.Element: MultipartPartBodyElement & RangeReplaceableCollec
     public struct AsyncIterator: AsyncIteratorProtocol {
         var streamingIterator: StreamingMultipartParserAsyncSequence<BackingSequence>.AsyncIterator
 
-        public mutating func next() async throws -> MultipartSection<BackingSequence.Element>? {
+        public mutating func next() async throws(MultipartParserError) -> MultipartSection<BackingSequence.Element>? {
             try await streamingIterator.nextCollatedPart()
+        }
+
+        @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+        public mutating func next(isolation actor: isolated (any Actor)?) async throws(MultipartParserError)
+            -> MultipartSection<BackingSequence.Element>?
+        {
+            try await streamingIterator.nextCollatedPart(isolation: actor)
         }
     }
 

--- a/Sources/MultipartKit/MultipartParserAsyncSequence.swift
+++ b/Sources/MultipartKit/MultipartParserAsyncSequence.swift
@@ -43,7 +43,7 @@ where BackingSequence.Element: MultipartPartBodyElement & RangeReplaceableCollec
         }
 
         @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-        public mutating func next(isolation actor: isolated (any Actor)?) async throws(MultipartParserError)
+        public mutating func next(isolation actor: isolated (any Actor)? = #isolation) async throws(MultipartParserError)
             -> MultipartSection<BackingSequence.Element>?
         {
             try await streamingIterator.nextCollatedPart(isolation: actor)

--- a/Sources/MultipartKit/MultipartParserError.swift
+++ b/Sources/MultipartKit/MultipartParserError.swift
@@ -46,7 +46,7 @@ public struct MultipartParserError: Swift.Error, Equatable, Sendable {
     }
 
     public static let invalidBoundary = Self(errorType: .invalidBoundary)
-  
+
     public static let unexpectedEndOfFile = Self(errorType: .unexpectedEndOfFile)
 
     public static func invalidHeader(reason: String) -> Self {
@@ -56,7 +56,7 @@ public struct MultipartParserError: Swift.Error, Equatable, Sendable {
     public static func invalidBody(reason: String) -> Self {
         .init(backing: .init(errorType: .invalidBody, reason: reason))
     }
-  
+
     public static func backingSequenceError(reason: String) -> Self {
         .init(backing: .init(errorType: .backingSequenceError, reason: reason))
     }

--- a/Sources/MultipartKit/MultipartParserError.swift
+++ b/Sources/MultipartKit/MultipartParserError.swift
@@ -1,7 +1,9 @@
 /// Technical parsing error, such as malformed data or invalid characters.
 /// This is mainly used by ``MultipartParser``.
-package enum MultipartParserError: Swift.Error, Equatable {
+public enum MultipartParserError: Swift.Error, Equatable {
     case invalidBoundary
     case invalidHeader(reason: String)
     case invalidBody(reason: String)
+    case unexpectedEndOfFile
+    case backingSequenceError(underlyingReason: String)
 }

--- a/Sources/MultipartKit/StreamingMultipartParserAsyncSequence+Isolation.swift
+++ b/Sources/MultipartKit/StreamingMultipartParserAsyncSequence+Isolation.swift
@@ -37,7 +37,7 @@ extension StreamingMultipartParserAsyncSequence.AsyncIterator {
                 do {
                     next = try await iterator.next(isolation: actor)
                 } catch {
-                    throw MultipartParserError.backingSequenceError(underlyingReason: "\(error)")
+                    throw MultipartParserError.backingSequenceError(reason: "\(error)")
                 }
                 if let next {
                     parser.append(buffer: next)

--- a/Sources/MultipartKit/StreamingMultipartParserAsyncSequence+Isolation.swift
+++ b/Sources/MultipartKit/StreamingMultipartParserAsyncSequence+Isolation.swift
@@ -2,7 +2,7 @@ import HTTPTypes
 
 extension StreamingMultipartParserAsyncSequence.AsyncIterator {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public mutating func next(isolation actor: isolated (any Actor)?) async throws(MultipartParserError) -> Self.Element? {
+    public mutating func next(isolation actor: isolated (any Actor)? = #isolation) async throws(MultipartParserError) -> Self.Element? {
         if let pendingBodyChunk {
             defer { self.pendingBodyChunk = nil }
             return .bodyChunk(pendingBodyChunk)
@@ -58,7 +58,7 @@ extension StreamingMultipartParserAsyncSequence.AsyncIterator {
     }
 
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public mutating func nextCollatedPart(isolation actor: isolated (any Actor)?) async throws(MultipartParserError)
+    public mutating func nextCollatedPart(isolation actor: isolated (any Actor)? = #isolation) async throws(MultipartParserError)
         -> MultipartSection<BackingSequence.Element>?
     {
         var headerFields = HTTPFields()

--- a/Sources/MultipartKit/StreamingMultipartParserAsyncSequence+Isolation.swift
+++ b/Sources/MultipartKit/StreamingMultipartParserAsyncSequence+Isolation.swift
@@ -1,0 +1,85 @@
+import HTTPTypes
+
+extension StreamingMultipartParserAsyncSequence.AsyncIterator {
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    public mutating func next(isolation actor: isolated (any Actor)?) async throws(MultipartParserError) -> Self.Element? {
+        if let pendingBodyChunk {
+            defer { self.pendingBodyChunk = nil }
+            return .bodyChunk(pendingBodyChunk)
+        }
+
+        var headerFields = HTTPFields()
+
+        while true {
+            switch parser.read() {
+            case .success(let optionalPart):
+                switch optionalPart {
+                case .none: continue
+                case .some(let part):
+                    switch part {
+                    case .headerFields(let fields):
+                        headerFields.append(contentsOf: fields)
+                        continue
+                    case .bodyChunk(let chunk):
+                        if !headerFields.isEmpty {
+                            pendingBodyChunk = chunk
+                            let returningFields = headerFields
+                            headerFields = .init()
+                            return .headerFields(returningFields)
+                        }
+                        return .bodyChunk(chunk)
+                    case .boundary:
+                        return part
+                    }
+                }
+            case .needMoreData:
+                let next: BackingSequence.Element?
+                do {
+                    next = try await iterator.next(isolation: actor)
+                } catch {
+                    throw MultipartParserError.backingSequenceError(underlyingReason: "\(error)")
+                }
+                if let next {
+                    parser.append(buffer: next)
+                } else {
+                    switch parser.state {
+                    case .initial, .finished:
+                        return nil
+                    case .parsing:
+                        throw MultipartParserError.unexpectedEndOfFile
+                    }
+                }
+            case .error(let error):
+                throw error
+            case .finished:
+                return nil
+            }
+        }
+    }
+
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    public mutating func nextCollatedPart(isolation actor: isolated (any Actor)?) async throws(MultipartParserError)
+        -> MultipartSection<BackingSequence.Element>?
+    {
+        var headerFields = HTTPFields()
+
+        while let part = try await self.next(isolation: actor) {
+            switch part {
+            case .headerFields(let fields):
+                headerFields.append(contentsOf: fields)
+            case .bodyChunk(let chunk):
+                self.currentCollatedBody.append(contentsOf: chunk)
+                if !headerFields.isEmpty {
+                    defer { headerFields = .init() }
+                    return .headerFields(headerFields)
+                }
+            case .boundary:
+                if !currentCollatedBody.isEmpty {
+                    defer { currentCollatedBody = .init() }
+                    return .bodyChunk(currentCollatedBody)
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/MultipartKit/StreamingMultipartParserAsyncSequence.swift
+++ b/Sources/MultipartKit/StreamingMultipartParserAsyncSequence.swift
@@ -81,7 +81,7 @@ where BackingSequence.Element: MultipartPartBodyElement & RangeReplaceableCollec
                     do {
                         next = try await iterator.next()
                     } catch {
-                        throw MultipartParserError.backingSequenceError(underlyingReason: "\(error)")
+                        throw MultipartParserError.backingSequenceError(reason: "\(error)")
                     }
                     if let next {
                         parser.append(buffer: next)

--- a/Tests/MultipartKitTests/ParserTests.swift
+++ b/Tests/MultipartKitTests/ParserTests.swift
@@ -141,7 +141,7 @@ struct ParserTests {
             """.utf8
         )
 
-        #expect(throws: MultipartMessageError.unexpectedEndOfFile) {
+        #expect(throws: MultipartParserError.unexpectedEndOfFile) {
             _ = try MultipartParser<[UInt8]>(boundary: boundary)
                 .parse([UInt8](message))
         }
@@ -149,7 +149,7 @@ struct ParserTests {
         let stream = makeParsingStream(for: message)
         var iterator = StreamingMultipartParserAsyncSequence(boundary: boundary, buffer: stream).makeAsyncIterator()
 
-        await #expect(throws: MultipartMessageError.unexpectedEndOfFile) {
+        await #expect(throws: MultipartParserError.unexpectedEndOfFile) {
             while (try await iterator.next()) != nil {}
         }
     }
@@ -216,7 +216,7 @@ struct ParserTests {
             """.utf8
         )
 
-        #expect(throws: MultipartMessageError.unexpectedEndOfFile) {
+        #expect(throws: MultipartParserError.unexpectedEndOfFile) {
             _ = try MultipartParser<[UInt8]>(boundary: boundary)
                 .parse([UInt8](message))
         }
@@ -224,7 +224,7 @@ struct ParserTests {
         let stream = makeParsingStream(for: message)
         var iterator = StreamingMultipartParserAsyncSequence(boundary: boundary, buffer: stream).makeAsyncIterator()
 
-        await #expect(throws: MultipartMessageError.unexpectedEndOfFile) {
+        await #expect(throws: MultipartParserError.unexpectedEndOfFile) {
             while (try await iterator.next()) != nil {}
         }
     }


### PR DESCRIPTION
This adds support to use `AsyncIteratorProtocol.next(isolation:)` and therefore adopts typed throws in the parse asynchronous sequences. 

Fixes #108, fixes #109 

Relies on #111 