### PR TITLE
Remove serialize into String method

### DIFF
--- a/Sources/MultipartKit/FormDataEncoder/FormDataEncoder.swift
+++ b/Sources/MultipartKit/FormDataEncoder/FormDataEncoder.swift
@@ -24,7 +24,8 @@ public struct FormDataEncoder: Sendable {
     /// - returns: `multipart/form-data`-encoded `String`.
     public func encode<E: Encodable>(_ encodable: E, boundary: String) throws -> String {
         let parts: [MultipartPart<[UInt8]>] = try self.parts(from: encodable)
-        return MultipartSerializer(boundary: boundary).serialize(parts: parts)
+        let serialized = MultipartSerializer(boundary: boundary).serialize(parts: parts, into: [UInt8].self)
+        return String(decoding: serialized, as: Unicode.UTF8.self)
     }
 
     /// Encodes an `Encodable` item into some ``MultipartPartBodyElement`` using the supplied boundary.

--- a/Sources/MultipartKit/MultipartSerializer.swift
+++ b/Sources/MultipartKit/MultipartSerializer.swift
@@ -16,27 +16,14 @@ public struct MultipartSerializer: Sendable {
     /// - Parameters:
     ///   - parts: One or more ``MultipartPart``s to serialize into some ``MultipartPartBodyElement``.
     /// - Returns: some `multipart`-encoded ``MultipartPartBodyElement``.
-    public func serialize<Body: MultipartPartBodyElement>(parts: [MultipartPart<some MultipartPartBodyElement>]) -> Body
+    public func serialize<Body: MultipartPartBodyElement>(
+        parts: [MultipartPart<some MultipartPartBodyElement>],
+        into: Body.Type = Body.self
+    ) -> Body
     where Body: RangeReplaceableCollection {
         var buffer = Body()
         self.serialize(parts: parts, into: &buffer)
         return buffer
-    }
-
-    /// Serializes some ``MultipartPartBodyElement`` to a `String`.
-    ///
-    /// ```swift
-    /// let serialized: String = MultipartSerializer(boundary: "123").serialize(parts: [part])
-    /// ```
-    ///
-    /// - Parameters:
-    ///   - parts: One or more ``MultipartPart``s to serialize into some ``MultipartPartBodyElement``.
-    /// - Returns: a `multipart`-encoded `String`.
-    public func serialize<Body: MultipartPartBodyElement>(parts: [MultipartPart<Body>]) -> String
-    where Body: RangeReplaceableCollection {
-        var buffer = Body()
-        self.serialize(parts: parts, into: &buffer)
-        return String(decoding: buffer, as: UTF8.self)
     }
 
     /// Serializes some ``MultipartPart``s to a buffer.


### PR DESCRIPTION
This removes the `MultipartSerializer.serialize(parts:) -> String` method in favour of keeping the generic bytes one. We're not accepting String as input so we don't necessarily need to return the serialised thing as Strings either. This also adds a parameter to be able to specify the generic body type we're serialising into 

Addresses #113 