### PR TITLE
Add back `MultipartPartConvertible`

### DIFF
--- a/Sources/MultipartKit/FormDataDecoder/FormDataDecoder+SingleValueContainer.swift
+++ b/Sources/MultipartKit/FormDataDecoder/FormDataDecoder+SingleValueContainer.swift
@@ -93,6 +93,8 @@ extension FormDataDecoder.Decoder: SingleValueDecodingContainer {
 
         let decoded =
             switch T.self {
+            case let multipartConvertible as any MultipartPartConvertible.Type:
+                multipartConvertible.init(multipart: part) as? T
             case is MultipartPart<Body>.Type:
                 part as? T
             case is Data.Type:

--- a/Sources/MultipartKit/FormDataDecoder/FormDataDecoder.swift
+++ b/Sources/MultipartKit/FormDataDecoder/FormDataDecoder.swift
@@ -54,7 +54,7 @@ public struct FormDataDecoder: Sendable {
         _ decodable: D.Type,
         from buffer: Body,
         boundary: String
-    ) throws -> D where Body: RangeReplaceableCollection, Body.SubSequence: Equatable & Sendable {
+    ) throws -> D where Body.SubSequence: Equatable & Sendable {
         let parts = try MultipartParser(boundary: boundary).parse(buffer)
         let data = MultipartFormData(parts: parts, nestingDepth: nestingDepth)
         let decoder = FormDataDecoder.Decoder(codingPath: [], data: data, userInfo: userInfo)

--- a/Sources/MultipartKit/FormDataEncoder/FormDataEncoder+Encoder.swift
+++ b/Sources/MultipartKit/FormDataEncoder/FormDataEncoder+Encoder.swift
@@ -1,5 +1,5 @@
 extension FormDataEncoder {
-    struct Encoder<Body: MultipartPartBodyElement> where Body: RangeReplaceableCollection {
+    struct Encoder<Body: MultipartPartBodyElement> {
         let codingPath: [any CodingKey]
         let storage = Storage<Body>()
         let sendableUserInfo: [CodingUserInfoKey: any Sendable]

--- a/Sources/MultipartKit/FormDataEncoder/FormDataEncoder+KeyedContainer.swift
+++ b/Sources/MultipartKit/FormDataEncoder/FormDataEncoder+KeyedContainer.swift
@@ -1,5 +1,5 @@
 extension FormDataEncoder {
-    struct KeyedContainer<Key: CodingKey, Body: MultipartPartBodyElement> where Body: RangeReplaceableCollection {
+    struct KeyedContainer<Key: CodingKey, Body: MultipartPartBodyElement> {
         let dataContainer = KeyedDataContainer<Body>()
         let encoder: Encoder<Body>
     }

--- a/Sources/MultipartKit/FormDataEncoder/FormDataEncoder+SingleValueContainer.swift
+++ b/Sources/MultipartKit/FormDataEncoder/FormDataEncoder+SingleValueContainer.swift
@@ -46,6 +46,11 @@ extension FormDataEncoder.Encoder: SingleValueEncodingContainer {
 
     func encode<T: Encodable>(_ value: T) throws {
         switch value {
+        case let multipartConvertible as any MultipartPartConvertible<Body>:
+            guard let multipart = multipartConvertible.multipart else {
+                return try value.encode(to: self)
+            }
+            storage.dataContainer = SingleValueDataContainer(part: multipart)
         case let multipart as MultipartPart<Body>:
             storage.dataContainer = SingleValueDataContainer(part: multipart)
         case let data as Data:

--- a/Sources/MultipartKit/FormDataEncoder/FormDataEncoder+UnkeyedContainer.swift
+++ b/Sources/MultipartKit/FormDataEncoder/FormDataEncoder+UnkeyedContainer.swift
@@ -1,5 +1,5 @@
 extension FormDataEncoder {
-    struct UnkeyedContainer<Body: MultipartPartBodyElement> where Body: RangeReplaceableCollection {
+    struct UnkeyedContainer<Body: MultipartPartBodyElement> {
         let dataContainer = UnkeyedDataContainer<Body>()
         let encoder: FormDataEncoder.Encoder<Body>
     }

--- a/Sources/MultipartKit/FormDataEncoder/FormDataEncoder.swift
+++ b/Sources/MultipartKit/FormDataEncoder/FormDataEncoder.swift
@@ -45,13 +45,12 @@ public struct FormDataEncoder: Sendable {
         _ encodable: E,
         boundary: String,
         to: Body.Type = Body.self
-    ) throws -> Body where Body: RangeReplaceableCollection {
+    ) throws -> Body {
         let parts: [MultipartPart<Body>] = try self.parts(from: encodable)
         return MultipartSerializer(boundary: boundary).serialize(parts: parts)
     }
 
-    private func parts<E: Encodable, Body: MultipartPartBodyElement>(from encodable: E) throws -> [MultipartPart<Body>]
-    where Body: RangeReplaceableCollection {
+    private func parts<E: Encodable, Body: MultipartPartBodyElement>(from encodable: E) throws -> [MultipartPart<Body>] {
         let encoder = Encoder<Body>(codingPath: [], userInfo: userInfo)
         try encodable.encode(to: encoder)
         return encoder.storage.data?.namedParts() ?? []

--- a/Sources/MultipartKit/MultipartParser+parse.swift
+++ b/Sources/MultipartKit/MultipartParser+parse.swift
@@ -2,7 +2,7 @@ import HTTPTypes
 
 extension MultipartParser {
     /// Synchronously parse the multipart data into an array of ``MultipartPart``.
-    public func parse(_ data: Body) throws -> [MultipartPart<Body>] where Body: RangeReplaceableCollection {
+    public func parse(_ data: Body) throws -> [MultipartPart<Body>] {
         var output: [MultipartPart<Body>] = []
         var parser = MultipartParser(boundary: self.boundary)
 

--- a/Sources/MultipartKit/MultipartParser.swift
+++ b/Sources/MultipartKit/MultipartParser.swift
@@ -1,7 +1,7 @@
 import HTTPTypes
 
 /// Parses any kind of multipart encoded data into ``MultipartSection``s.
-public struct MultipartParser<Body: MultipartPartBodyElement> where Body: RangeReplaceableCollection {
+public struct MultipartParser<Body: MultipartPartBodyElement> {
     enum State: Equatable {
         enum Part: Equatable {
             case boundary

--- a/Sources/MultipartKit/MultipartParserAsyncSequence.swift
+++ b/Sources/MultipartKit/MultipartParserAsyncSequence.swift
@@ -28,7 +28,7 @@ import HTTPTypes
 /// ```
 ///
 public struct MultipartParserAsyncSequence<BackingSequence: AsyncSequence>: AsyncSequence
-where BackingSequence.Element: MultipartPartBodyElement & RangeReplaceableCollection {
+where BackingSequence.Element: MultipartPartBodyElement {
     let streamingSequence: StreamingMultipartParserAsyncSequence<BackingSequence>
 
     public init(boundary: String, buffer: BackingSequence) {

--- a/Sources/MultipartKit/MultipartPart.swift
+++ b/Sources/MultipartKit/MultipartPart.swift
@@ -1,6 +1,6 @@
 import HTTPTypes
 
-public typealias MultipartPartBodyElement = Collection<UInt8> & Sendable
+public typealias MultipartPartBodyElement = Collection<UInt8> & Sendable & RangeReplaceableCollection
 
 /// Represents a single part of a multipart-encoded message.
 public struct MultipartPart<Body: MultipartPartBodyElement>: Sendable {
@@ -19,7 +19,7 @@ public struct MultipartPart<Body: MultipartPartBodyElement>: Sendable {
     /// - Parameters:
     ///  - headerFields: The header fields for this part.
     ///  - body: The body of this part.
-    public init(headerFields: HTTPFields, body: Body) {
+    public init(headerFields: HTTPFields = .init(), body: Body) {
         self.headerFields = headerFields
         self.body = body
     }

--- a/Sources/MultipartKit/MultipartPartConvertible.swift
+++ b/Sources/MultipartKit/MultipartPartConvertible.swift
@@ -1,0 +1,17 @@
+/// A protocol to provide custom behaviors for parsing and serializing types from and to multipart data.
+public protocol MultipartPartConvertible<Body> {
+    associatedtype Body: MultipartPartBodyElement
+
+    var multipart: MultipartPart<Body>? { get }
+    init?(multipart: MultipartPart<some MultipartPartBodyElement>)
+}
+
+extension MultipartPart: MultipartPartConvertible {
+    public var multipart: MultipartPart<Body>? {
+        self
+    }
+
+    public init?(multipart: MultipartPart<some MultipartPartBodyElement>) {
+        self = .init(headerFields: multipart.headerFields, body: .init(multipart.body))
+    }
+}

--- a/Sources/MultipartKit/MultipartSerializer.swift
+++ b/Sources/MultipartKit/MultipartSerializer.swift
@@ -19,7 +19,7 @@ public struct MultipartSerializer: Sendable {
     public func serialize<Body: MultipartPartBodyElement>(
         parts: [MultipartPart<some MultipartPartBodyElement>],
         into: Body.Type = Body.self
-    ) -> Body where Body: RangeReplaceableCollection {
+    ) -> Body {
         var buffer = Body()
         self.serialize(parts: parts, into: &buffer)
         return buffer
@@ -40,7 +40,7 @@ public struct MultipartSerializer: Sendable {
     public func serialize<OutputBody: MultipartPartBodyElement>(
         parts: [MultipartPart<some MultipartPartBodyElement>],
         into buffer: inout OutputBody
-    ) where OutputBody: RangeReplaceableCollection {
+    ) {
         for part in parts {
             buffer.append(.hyphen)
             buffer.append(.hyphen)

--- a/Sources/MultipartKit/StreamingMultipartParserAsyncSequence.swift
+++ b/Sources/MultipartKit/StreamingMultipartParserAsyncSequence.swift
@@ -27,7 +27,7 @@ import HTTPTypes
 /// ```
 ///
 public struct StreamingMultipartParserAsyncSequence<BackingSequence: AsyncSequence>: AsyncSequence
-where BackingSequence.Element: MultipartPartBodyElement & RangeReplaceableCollection {
+where BackingSequence.Element: MultipartPartBodyElement {
     let parser: MultipartParser<BackingSequence.Element>
     let buffer: BackingSequence
 

--- a/Sources/MultipartKit/Utilities.swift
+++ b/Sources/MultipartKit/Utilities.swift
@@ -4,7 +4,7 @@ import HTTPTypes
 extension HTTPFields {
     func getParameter(_ name: HTTPField.Name, _ key: String) -> String? {
         headerParts(name: name)?
-            .filter { $0.contains("\(key)=") }
+            .filter { $0.starts(with: "\(key)=") }
             .first?
             .split(separator: "=")
             .last?

--- a/Tests/MultipartKitTests/FormDataDecodingTests.swift
+++ b/Tests/MultipartKitTests/FormDataDecodingTests.swift
@@ -304,8 +304,7 @@ struct FormDataDecodingTests {
         }
     }
 
-    // https://github.com/vapor/multipart-kit/issues/123
-    @Test("Decoding with key containing square bracket")
+    @Test("Decoding with key containing square bracket", .bug("https://github.com/vapor/multipart-kit/issues/123"))
     func decodeWithKeyContainingBracket() async throws {
         struct HasADict: Codable, Equatable {
             var hints: [String: String]
@@ -342,6 +341,43 @@ struct FormDataDecodingTests {
 
         let deserializedBar = try FormDataDecoder().decode(HasADict.self, from: serializedBar, boundary: "hello")
         #expect(deserializedBar == bar)
+    }
+
+    @Test("Decode simil-Vapor File type")
+    func decodeSimilVaporFileType() async throws {
+        struct User: Codable {
+            var name: String
+            var age: Int
+            var image: File
+        }
+
+        let user = User(
+            name: "Vapor",
+            age: 4,
+            image: File(filename: "droplet.png", data: Array("<contents of image>".utf8)))
+
+        let message = ArraySlice(
+            """
+            --helloBoundary\r
+            Content-Disposition: form-data; name="name"\r
+            \r
+            Vapor\r
+            --helloBoundary\r
+            Content-Disposition: form-data; name="age"\r
+            \r
+            4\r
+            --helloBoundary\r
+            Content-Disposition: form-data; filename="droplet.png"; name="image"\r
+            \r
+            <contents of image>\r
+            --helloBoundary--\r\n
+            """.utf8)
+
+        let decoded = try FormDataDecoder().decode(User.self, from: message, boundary: "helloBoundary")
+
+        #expect(decoded.name == user.name)
+        #expect(decoded.age == user.age)
+        #expect(decoded.image == user.image)
     }
 
 }

--- a/Tests/MultipartKitTests/FormDataEncodingTests.swift
+++ b/Tests/MultipartKitTests/FormDataEncodingTests.swift
@@ -177,8 +177,7 @@ struct FormDataEncodingTests {
         #expect(try FormDataDecoder().decode(UUID.self, from: multipart, boundary: "-") == uuid)
     }
 
-    // https://github.com/vapor/multipart-kit/issues/65
-    @Test("Encoding and Decoding Non-Multipart Part Convertible Codable Types")
+    @Test("Encoding and Decoding Non-Multipart Part Convertible Codable Types", .bug("https://github.com/vapor/multipart-kit/issues/65"))
     func encodeAndDecodeNonMultipartPartConvertibleCodableTypes() async throws {
         enum License: String, Codable, CaseIterable, Equatable {
             case dme1

--- a/Tests/MultipartKitTests/FormDataEncodingTests.swift
+++ b/Tests/MultipartKitTests/FormDataEncodingTests.swift
@@ -283,5 +283,41 @@ struct FormDataEncodingTests {
         #expect(try FormDataEncoder().encode(value, boundary: "-") == multipart)
         #expect(try FormDataDecoder().decode(AllTypes.self, from: multipart, boundary: "-") == value)
     }
+
+    @Test("Encode simil-Vapor File type")
+    func encodeSimilVaporFileType() async throws {
+        struct User: Codable {
+            var name: String
+            var age: Int
+            var image: File
+        }
+
+        let user = User(
+            name: "Vapor",
+            age: 4,
+            image: File(filename: "droplet.png", data: Array("<contents of image>".utf8)))
+
+        let encoder = FormDataEncoder()
+        let boundary = "helloBoundary"
+        let encoded = try encoder.encode(user, boundary: boundary)
+
+        let expected = """
+            --helloBoundary\r
+            Content-Disposition: form-data; name="name"\r
+            \r
+            Vapor\r
+            --helloBoundary\r
+            Content-Disposition: form-data; name="age"\r
+            \r
+            4\r
+            --helloBoundary\r
+            Content-Disposition: form-data; filename="droplet.png"; name="image"\r
+            \r
+            <contents of image>\r
+            --helloBoundary--\r\n
+            """
+
+        #expect(encoded == expected)
+    }
 }
 #endif  // canImport(Testing)

--- a/Tests/MultipartKitTests/ParserTests.swift
+++ b/Tests/MultipartKitTests/ParserTests.swift
@@ -150,7 +150,7 @@ struct ParserTests {
         var iterator = StreamingMultipartParserAsyncSequence(boundary: boundary, buffer: stream).makeAsyncIterator()
 
         await #expect(throws: MultipartParserError.unexpectedEndOfFile) {
-            while (try await iterator.next()) != nil {}
+            while try await iterator.next() != nil {}
         }
     }
 
@@ -175,7 +175,7 @@ struct ParserTests {
         var iterator = StreamingMultipartParserAsyncSequence(boundary: boundary, buffer: stream).makeAsyncIterator()
 
         await #expect(throws: MultipartParserError.invalidHeader(reason: "Invalid header name")) {
-            while (try await iterator.next()) != nil {}
+            while try await iterator.next() != nil {}
         }
     }
 
@@ -225,7 +225,7 @@ struct ParserTests {
         var iterator = StreamingMultipartParserAsyncSequence(boundary: boundary, buffer: stream).makeAsyncIterator()
 
         await #expect(throws: MultipartParserError.unexpectedEndOfFile) {
-            while (try await iterator.next()) != nil {}
+            while try await iterator.next() != nil {}
         }
     }
 

--- a/Tests/MultipartKitTests/Utilities/File.swift
+++ b/Tests/MultipartKitTests/Utilities/File.swift
@@ -1,0 +1,52 @@
+import MultipartKit
+
+struct File: Codable, Equatable, MultipartPartConvertible {
+    let filename: String
+    let data: [UInt8]
+
+    enum CodingKeys: String, CodingKey {
+        case data, filename
+    }
+
+    init(filename: String, data: [UInt8]) {
+        self.filename = filename
+        self.data = data
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let data = try container.decode([UInt8].self, forKey: .data)
+        let filename = try container.decode(String.self, forKey: .filename)
+        self.init(filename: filename, data: data)
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(data, forKey: .data)
+        try container.encode(self.filename, forKey: .filename)
+    }
+
+    var multipart: MultipartPart<[UInt8]>? {
+        let part = MultipartPart(
+            headerFields: [.contentDisposition: "form-data; name=\"image\"; filename=\"\(filename)\""],
+            body: self.data)
+        return part
+    }
+
+    init?(multipart: MultipartPart<some MultipartPartBodyElement>) {
+        let contentDisposition = multipart.headerFields[.contentDisposition] ?? ""
+        let filenamePattern = "filename=\"([^\"]+)\""
+        let filename: String
+
+        if let range = contentDisposition.range(of: filenamePattern, options: .regularExpression) {
+            let match = contentDisposition[range]
+            let startIndex = match.index(match.startIndex, offsetBy: 10)  // Skip 'filename="'
+            let endIndex = match.index(before: match.endIndex)  // Skip closing quote
+            filename = String(contentDisposition[startIndex..<endIndex])
+        } else {
+            return nil
+        }
+
+        self.init(filename: filename, data: Array(multipart.body))
+    }
+}


### PR DESCRIPTION
This adds back the `MultipartPartConvertible` protocol to be able to create multipart parts out of custom `Codable` types, e.g [Vapor's `File`](https://github.com/vapor/vapor/blob/vapor-5/Sources/Vapor/Multipart/File%2BMultipart.swift#L6)