### PR TITLE
Split `MultipartPartConvertible` into two

### DIFF
--- a/Sources/MultipartKit/FormDataDecoder/FormDataDecoder+SingleValueContainer.swift
+++ b/Sources/MultipartKit/FormDataDecoder/FormDataDecoder+SingleValueContainer.swift
@@ -94,7 +94,7 @@ extension FormDataDecoder.Decoder: SingleValueDecodingContainer {
         let decoded =
             switch T.self {
             case let multipartConvertible as any MultipartPartConvertible.Type:
-                multipartConvertible.init(multipart: part) as? T
+                try multipartConvertible.init(multipart: part) as? T
             case is MultipartPart<Body>.Type:
                 part as? T
             case is Data.Type:

--- a/Sources/MultipartKit/FormDataEncoder/FormDataEncoder+SingleValueContainer.swift
+++ b/Sources/MultipartKit/FormDataEncoder/FormDataEncoder+SingleValueContainer.swift
@@ -47,7 +47,10 @@ extension FormDataEncoder.Encoder: SingleValueEncodingContainer {
     func encode<T: Encodable>(_ value: T) throws {
         switch value {
         case let multipartConvertible as any MultipartPartConvertible<Body>:
-            guard let multipart = multipartConvertible.multipart else {
+            let multipart: MultipartPart<Body>
+            do {
+                multipart = try multipartConvertible.multipart
+            } catch {
                 return try value.encode(to: self)
             }
             storage.dataContainer = SingleValueDataContainer(part: multipart)

--- a/Sources/MultipartKit/MultipartPartConvertible.swift
+++ b/Sources/MultipartKit/MultipartPartConvertible.swift
@@ -1,17 +1,23 @@
 /// A protocol to provide custom behaviors for parsing and serializing types from and to multipart data.
-public protocol MultipartPartConvertible<Body> {
+
+public protocol MultipartPartEncodable<Body> {
     associatedtype Body: MultipartPartBodyElement
 
-    var multipart: MultipartPart<Body>? { get }
-    init?(multipart: MultipartPart<some MultipartPartBodyElement>)
+    var multipart: MultipartPart<Body> { get throws }
 }
 
+public protocol MultipartPartDecodable {
+    init(multipart: MultipartPart<some MultipartPartBodyElement>) throws
+}
+
+public protocol MultipartPartConvertible<Body>: MultipartPartEncodable, MultipartPartDecodable where Body == Self.Body {}
+
 extension MultipartPart: MultipartPartConvertible {
-    public var multipart: MultipartPart<Body>? {
+    public var multipart: MultipartPart<Body> {
         self
     }
 
-    public init?(multipart: MultipartPart<some MultipartPartBodyElement>) {
+    public init(multipart: MultipartPart<some MultipartPartBodyElement>) {
         self = .init(headerFields: multipart.headerFields, body: .init(multipart.body))
     }
 }

--- a/Tests/MultipartKitTests/SerializerTests.swift
+++ b/Tests/MultipartKitTests/SerializerTests.swift
@@ -17,7 +17,7 @@ struct SerializerTests {
             )
         ]
 
-        let serialized: ArraySlice<UInt8> = MultipartSerializer(boundary: "boundary123").serialize(parts: example)
+        let serialized = MultipartSerializer(boundary: "boundary123").serialize(parts: example, into: ArraySlice<UInt8>.self)
         let expected = ArraySlice(
             """
             --boundary123\r


### PR DESCRIPTION
This splits the `MultipartPartConvertible` protocol into two separate ones for encoding and decoding. Naming could be also reconsidered to a `MultipartPartCodable` to follow along with Swift standards.

This also makes the `init` throw instead of fail and the `multipart` property throw instead of return `nil` for better error diagnostics.

Closes #131 